### PR TITLE
Expose build metadata in version endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 APP_NAME=meridian-backend
 ENV=development
 VERSION=0.1.0
+GIT_SHA=
+BUILD_TIME=
 POSTGRES_DSN=postgresql+asyncpg://postgres:postgres@localhost:5432/meridian
 MONGO_DSN=mongodb://localhost:27017
 REDIS_DSN=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Configuration is read from `/etc/meridian/.env`.
 | `APP_NAME` | Application name used for logging |
 | `ENV` | Environment identifier (`development`, `production`, etc.) |
 | `VERSION` | Application version string |
+| `GIT_SHA` | Git commit SHA for the build |
+| `BUILD_TIME` | ISO8601 timestamp when the build was created |
 | `POSTGRES_DSN` | PostgreSQL connection string |
 | `MONGO_DSN` | MongoDB connection string |
 | `REDIS_DSN` | Redis connection string |

--- a/app/api/routers/health.py
+++ b/app/api/routers/health.py
@@ -62,4 +62,8 @@ async def readiness(response: Response) -> dict[str, Any]:
 
 @router.get("/version")  # type: ignore[misc]
 async def version() -> dict[str, str]:
-    return {"version": settings.version}
+    return {
+        "version": settings.version,
+        "git_sha": settings.git_sha,
+        "build_time": settings.build_time,
+    }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
     app_name: str = Field("meridian-backend", alias="APP_NAME")
     env: str = Field("development", alias="ENV")
     version: str = Field("0.1.0", alias="VERSION")
+    git_sha: str = Field("unknown", alias="GIT_SHA")
+    build_time: str = Field("unknown", alias="BUILD_TIME")
     postgres_dsn: str = Field(..., alias="POSTGRES_DSN")
     mongo_dsn: str = Field(..., alias="MONGO_DSN")
     redis_dsn: str = Field(..., alias="REDIS_DSN")

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
+from app.core.config import settings
 from app.main import app
 
 client = TestClient(app)
@@ -46,7 +47,11 @@ def test_healthz() -> None:
 def test_version() -> None:
     response = client.get("/version")
     assert response.status_code == 200
-    assert "version" in response.json()
+    assert response.json() == {
+        "version": settings.version,
+        "git_sha": settings.git_sha,
+        "build_time": settings.build_time,
+    }
 
 
 @patch("app.db.redis.init_client", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- include `git_sha` and `build_time` values in `/version` endpoint
- document `GIT_SHA` and `BUILD_TIME` variables
- assert version endpoint returns values from settings

## Testing
- `poetry run pre-commit run --files README.md tests/api/test_health.py`
- `poetry run pytest --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6898e49b2a1883239bd144ff200a44d8