### PR TITLE
Add shared DB/cache infrastructure and macro, rates, FX APIs

### DIFF
--- a/app/api/routers/assets.py
+++ b/app/api/routers/assets.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+router = APIRouter(tags=["assets"])
+
+
+@router.get("/assets/prices")
+async def get_asset_prices(
+    symbol: str = Query(..., example="AAPL"),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"asset_prices:{symbol}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT symbol, ts, open, high, low, close, volume FROM prices_eod "
+        "WHERE symbol = %(symbol)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM prices_eod WHERE symbol = %(symbol)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "symbol": symbol.upper(),
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp
+
+
+@router.get("/assets/indices")
+async def get_index_prices(
+    index_symbol: str = Query(..., example="SPX"),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"index_prices:{index_symbol}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+    sql = (
+        "SELECT index_symbol, ts, value FROM indices_eod "
+        "WHERE index_symbol = %(index_symbol)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM indices_eod WHERE index_symbol = %(index_symbol)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "index_symbol": index_symbol.upper(),
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp
+
+
+@router.get("/assets/fundamentals")
+async def get_fundamentals(
+    cik: str = Query(..., example="0000320193"),
+    fact: str = Query(..., example="Assets"),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"fundamentals:{cik}:{fact}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+    sql = (
+        "SELECT cik, fact, ts, value, unit FROM fundamentals_xbrl "
+        "WHERE cik = %(cik)s AND fact = %(fact)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM fundamentals_xbrl "
+        "WHERE cik = %(cik)s AND fact = %(fact)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "cik": cik,
+        "fact": fact,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp
+
+
+@router.get("/assets/earnings")
+async def get_earnings_events(
+    cik: str | None = Query(None, example="0000320193"),
+    ticker: str | None = Query(None, example="AAPL"),
+    q: str | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = (
+        f"earnings:{cik}:{ticker}:{q}:{start}:{end}:{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+    sql = (
+        "SELECT cik, ticker, ts, headline, url FROM earnings_events "
+        "WHERE (%(cik)s IS NULL OR cik = %(cik)s) "
+        "AND (%(ticker)s IS NULL OR ticker = %(ticker)s) "
+        "AND (%(q)s IS NULL OR headline ILIKE %(q_like)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts DESC LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM earnings_events "
+        "WHERE (%(cik)s IS NULL OR cik = %(cik)s) "
+        "AND (%(ticker)s IS NULL OR ticker = %(ticker)s) "
+        "AND (%(q)s IS NULL OR headline ILIKE %(q_like)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "cik": cik,
+        "ticker": ticker.upper() if ticker else None,
+        "q": q,
+        "q_like": f"%{q}%" if q else None,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp

--- a/app/api/routers/assets.py
+++ b/app/api/routers/assets.py
@@ -73,7 +73,8 @@ async def get_index_prices(
         "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
     )
     count_sql = (
-        "SELECT COUNT(*) as count FROM indices_eod WHERE index_symbol = %(index_symbol)s "
+        "SELECT COUNT(*) as count FROM indices_eod "
+        "WHERE index_symbol = %(index_symbol)s "
         "AND (%(start)s IS NULL OR ts >= %(start)s) "
         "AND (%(end)s IS NULL OR ts <= %(end)s)"
     )
@@ -142,9 +143,7 @@ async def get_earnings_events(
     end: datetime | None = None,
     page: Page = Depends(),
 ):
-    key = (
-        f"earnings:{cik}:{ticker}:{q}:{start}:{end}:{page.limit}:{page.offset}"
-    )
+    key = f"earnings:{cik}:{ticker}:{q}:{start}:{end}:{page.limit}:{page.offset}"
     cached = await cache.cache_get(key)
     if cached:
         if isinstance(cached, (bytes, str)):

--- a/app/api/routers/cb.py
+++ b/app/api/routers/cb.py
@@ -4,9 +4,8 @@ import json
 from datetime import datetime
 from enum import Enum
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.concurrency import run_in_threadpool
-from fastapi import Query
 
 from app.api.schemas.common import Page
 from app.core import cache, db
@@ -45,7 +44,8 @@ async def get_cb_statements(
         return cached
 
     sql = (
-        "SELECT statement_id, central_bank, type, published_at, title, url, hawkish_dovish_score "
+        "SELECT statement_id, central_bank, type, published_at, title, url, "
+        "hawkish_dovish_score "
         "FROM cb_statements "
         "WHERE central_bank = %(bank)s "
         "AND (%(type)s = 'any' OR type = %(type)s) "

--- a/app/api/routers/cb.py
+++ b/app/api/routers/cb.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+from fastapi import Query
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class CBBank(str, Enum):
+    FED = "FED"
+    ECB = "ECB"
+    BOE = "BOE"
+
+
+class CBType(str, Enum):
+    decision = "decision"
+    statement = "statement"
+    minutes = "minutes"
+    speech = "speech"
+    any = "any"
+
+
+router = APIRouter(tags=["central_bank"])
+
+
+@router.get("/cb")
+async def get_cb_statements(
+    bank: CBBank = Query(...),
+    type: CBType = CBType.any,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"cb:{bank.value}:{type.value}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT statement_id, central_bank, type, published_at, title, url, hawkish_dovish_score "
+        "FROM cb_statements "
+        "WHERE central_bank = %(bank)s "
+        "AND (%(type)s = 'any' OR type = %(type)s) "
+        "AND (%(start)s IS NULL OR published_at >= %(start)s) "
+        "AND (%(end)s IS NULL OR published_at <= %(end)s) "
+        "ORDER BY published_at DESC LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM cb_statements "
+        "WHERE central_bank = %(bank)s "
+        "AND (%(type)s = 'any' OR type = %(type)s) "
+        "AND (%(start)s IS NULL OR published_at >= %(start)s) "
+        "AND (%(end)s IS NULL OR published_at <= %(end)s)"
+    )
+    params = {
+        "bank": bank.value,
+        "type": type.value,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=60)
+    return resp

--- a/app/api/routers/chokepoints.py
+++ b/app/api/routers/chokepoints.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class VesselClass(str, Enum):
+    container = "container"
+    tanker = "tanker"
+    bulk = "bulk"
+    all = "all"
+
+
+router = APIRouter(tags=["logistics"])
+
+
+@router.get("/logistics/chokepoints/series")
+async def get_chokepoint_series(
+    chokepoint_id: str,
+    vessel_class: VesselClass = VesselClass.all,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = (
+        f"chokepoint_series:{chokepoint_id}:{vessel_class.value}:{start}:{end}:{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT chokepoint_id, vessel_class, ts, delay_hours "
+        "FROM chokepoint_delay_ts "
+        "WHERE chokepoint_id = %(chokepoint_id)s "
+        "AND (%(vessel_class)s = 'all' OR vessel_class = %(vessel_class)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM chokepoint_delay_ts "
+        "WHERE chokepoint_id = %(chokepoint_id)s "
+        "AND (%(vessel_class)s = 'all' OR vessel_class = %(vessel_class)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "chokepoint_id": chokepoint_id,
+        "vessel_class": vessel_class.value,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp
+
+
+@router.get("/logistics/chokepoints/snapshot")
+async def get_chokepoint_snapshot(
+    chokepoint_id: str, vessel_class: VesselClass = VesselClass.all
+):
+    key = f"chokepoint_snapshot:{chokepoint_id}:{vessel_class.value}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    if vessel_class == VesselClass.all:
+        sql = (
+            "SELECT DISTINCT ON (vessel_class) chokepoint_id, vessel_class, ts, delay_hours "
+            "FROM chokepoint_delay_ts WHERE chokepoint_id = %(chokepoint_id)s "
+            "ORDER BY vessel_class, ts DESC"
+        )
+        params = {"chokepoint_id": chokepoint_id}
+    else:
+        sql = (
+            "SELECT chokepoint_id, vessel_class, ts, delay_hours "
+            "FROM chokepoint_delay_ts WHERE chokepoint_id = %(chokepoint_id)s AND vessel_class = %(vessel_class)s "
+            "ORDER BY ts DESC LIMIT 1"
+        )
+        params = {"chokepoint_id": chokepoint_id, "vessel_class": vessel_class.value}
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    resp = {"data": rows}
+    await cache.cache_set(key, json.dumps(resp), ttl=15)
+    return resp
+
+
+@router.get("/logistics/chokepoints/ref")
+async def get_chokepoint_ref(chokepoint_id: str | None = None):
+    sql = (
+        "SELECT chokepoint_id, name, country FROM ref_chokepoints "
+        "WHERE (%(chokepoint_id)s IS NULL OR chokepoint_id = %(chokepoint_id)s)"
+    )
+    params = {"chokepoint_id": chokepoint_id}
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    return {"data": rows}

--- a/app/api/routers/chokepoints.py
+++ b/app/api/routers/chokepoints.py
@@ -30,7 +30,8 @@ async def get_chokepoint_series(
     page: Page = Depends(),
 ):
     key = (
-        f"chokepoint_series:{chokepoint_id}:{vessel_class.value}:{start}:{end}:{page.limit}:{page.offset}"
+        f"chokepoint_series:{chokepoint_id}:{vessel_class.value}:"
+        f"{start}:{end}:{page.limit}:{page.offset}"
     )
     cached = await cache.cache_get(key)
     if cached:
@@ -82,7 +83,8 @@ async def get_chokepoint_snapshot(
 
     if vessel_class == VesselClass.all:
         sql = (
-            "SELECT DISTINCT ON (vessel_class) chokepoint_id, vessel_class, ts, delay_hours "
+            "SELECT DISTINCT ON (vessel_class) chokepoint_id, vessel_class, ts, "
+            "delay_hours "
             "FROM chokepoint_delay_ts WHERE chokepoint_id = %(chokepoint_id)s "
             "ORDER BY vessel_class, ts DESC"
         )
@@ -90,7 +92,8 @@ async def get_chokepoint_snapshot(
     else:
         sql = (
             "SELECT chokepoint_id, vessel_class, ts, delay_hours "
-            "FROM chokepoint_delay_ts WHERE chokepoint_id = %(chokepoint_id)s AND vessel_class = %(vessel_class)s "
+            "FROM chokepoint_delay_ts WHERE chokepoint_id = %(chokepoint_id)s "
+            "AND vessel_class = %(vessel_class)s "
             "ORDER BY ts DESC LIMIT 1"
         )
         params = {"chokepoint_id": chokepoint_id, "vessel_class": vessel_class.value}

--- a/app/api/routers/commodities.py
+++ b/app/api/routers/commodities.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+from fastapi import Query
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class CommodityCode(str, Enum):
+    WTI = "WTI"
+    BRENT = "BRENT"
+    HENRY_HUB = "HENRY_HUB"
+    DIESEL_US = "DIESEL_US"
+    GASOLINE_US = "GASOLINE_US"
+    JET_US = "JET_US"
+    COPPER = "COPPER"
+    ALUMINUM = "ALUMINUM"
+    GOLD = "GOLD"
+    SILVER = "SILVER"
+    WHEAT = "WHEAT"
+    CORN = "CORN"
+    SOY = "SOY"
+
+
+router = APIRouter()
+
+
+@router.get("/commodities", tags=["commodities"])
+async def get_commodity_prices(
+    code: CommodityCode = Query(...),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"commodities:{code.value}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT commodity_code, ts, price, unit, source "
+        "FROM commodities_ts "
+        "WHERE commodity_code = %(code)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM commodities_ts "
+        "WHERE commodity_code = %(code)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "code": code.value,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp))
+    return resp
+
+
+@router.get("/freight/bdi", tags=["freight"])
+async def get_bdi_index(
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"bdi:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT index_code, ts, value, source "
+        "FROM freight_indices "
+        "WHERE index_code = 'BDI' "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM freight_indices "
+        "WHERE index_code = 'BDI' "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp))
+    return resp

--- a/app/api/routers/commodities.py
+++ b/app/api/routers/commodities.py
@@ -4,9 +4,8 @@ import json
 from datetime import datetime
 from enum import Enum
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.concurrency import run_in_threadpool
-from fastapi import Query
 
 from app.api.schemas.common import Page
 from app.core import cache, db

--- a/app/api/routers/fx.py
+++ b/app/api/routers/fx.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class FXPair(str, Enum):
+    usd_eur = "usd_eur"
+    usd_jpy = "usd_jpy"
+    usd_gbp = "usd_gbp"
+    usd_cad = "usd_cad"
+    usd_cny = "usd_cny"
+    usd_mxn = "usd_mxn"
+    usd_brl = "usd_brl"
+    usd_inr = "usd_inr"
+
+
+router = APIRouter(tags=["fx"])
+
+
+@router.get("/fx")
+async def get_fx_series(
+    pair: FXPair,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    metric = pair.value
+    key = f"fx:{metric}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT series_id, entity_id, metric, ts, value, unit, source "
+        "FROM metrics_ts "
+        "WHERE entity_id = 'US' AND metric = %(metric)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM metrics_ts "
+        "WHERE entity_id = 'US' AND metric = %(metric)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "metric": metric,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp))
+    return resp

--- a/app/api/routers/geo.py
+++ b/app/api/routers/geo.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class GeoSource(str, Enum):
+    gdelt_events = "gdelt_events"
+    reliefweb = "reliefweb"
+    any = "any"
+
+
+router = APIRouter(tags=["geo"])
+
+
+@router.get("/geo/events")
+async def get_geo_events(
+    source: GeoSource = GeoSource.any,
+    country: str | None = Query(None, min_length=2, max_length=2),
+    event_type: str | None = None,
+    goldstein_min: float | None = None,
+    goldstein_max: float | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = (
+        f"geo_events:{source.value}:{country}:{event_type}:{goldstein_min}:{goldstein_max}:"
+        f"{start}:{end}:{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT source, source_id, ts, event_type, country, lat, lon, actor1, actor2, "
+        "actor_roles, goldstein, people_impacted, importance, url "
+        "FROM geo_events "
+        "WHERE (%(source)s = 'any' OR source = %(source)s) "
+        "AND (%(country)s IS NULL OR country = %(country)s) "
+        "AND (%(event_type)s IS NULL OR event_type = %(event_type)s) "
+        "AND (%(goldstein_min)s IS NULL OR goldstein >= %(goldstein_min)s) "
+        "AND (%(goldstein_max)s IS NULL OR goldstein <= %(goldstein_max)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts DESC LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM geo_events "
+        "WHERE (%(source)s = 'any' OR source = %(source)s) "
+        "AND (%(country)s IS NULL OR country = %(country)s) "
+        "AND (%(event_type)s IS NULL OR event_type = %(event_type)s) "
+        "AND (%(goldstein_min)s IS NULL OR goldstein >= %(goldstein_min)s) "
+        "AND (%(goldstein_max)s IS NULL OR goldstein <= %(goldstein_max)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "source": source.value,
+        "country": country.upper() if country else None,
+        "event_type": event_type,
+        "goldstein_min": goldstein_min,
+        "goldstein_max": goldstein_max,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=15)
+    return resp
+
+
+@router.get("/geo/mentions")
+async def get_geo_mentions(
+    event_source_id: str | None = None,
+    lang: str | None = Query(None, min_length=2, max_length=2),
+    source_country: str | None = Query(None, min_length=2, max_length=2),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = (
+        f"geo_mentions:{event_source_id}:{lang}:{source_country}:{start}:{end}:"
+        f"{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT event_source_id, ts, lang, source_country, snippet, url "
+        "FROM geo_mentions "
+        "WHERE (%(event_source_id)s IS NULL OR event_source_id = %(event_source_id)s) "
+        "AND (%(lang)s IS NULL OR lang = %(lang)s) "
+        "AND (%(source_country)s IS NULL OR source_country = %(source_country)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts DESC LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM geo_mentions "
+        "WHERE (%(event_source_id)s IS NULL OR event_source_id = %(event_source_id)s) "
+        "AND (%(lang)s IS NULL OR lang = %(lang)s) "
+        "AND (%(source_country)s IS NULL OR source_country = %(source_country)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "event_source_id": event_source_id,
+        "lang": lang.lower() if lang else None,
+        "source_country": source_country.upper() if source_country else None,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp

--- a/app/api/routers/macro.py
+++ b/app/api/routers/macro.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class MacroMetric(str, Enum):
+    gdp_current_usd = "gdp_current_usd"
+    cpi_yoy_percent = "cpi_yoy_percent"
+    unemployment_percent = "unemployment_percent"
+    policy_rate_percent = "policy_rate_percent"
+    real_gdp_growth_percent = "real_gdp_growth_percent"
+    gov_debt_gdp_percent = "gov_debt_gdp_percent"
+    cpi_index = "cpi_index"
+    fx_reserves_usd = "fx_reserves_usd"
+    current_account_gdp_percent = "current_account_gdp_percent"
+
+
+router = APIRouter(tags=["macro"])
+
+
+@router.get("/macro")
+async def get_macro_series(
+    country: str = Query(..., min_length=3, max_length=3),
+    metric: MacroMetric = Query(...),
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"macro:{country}:{metric.value}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT series_id, entity_id, metric, ts, value, unit, source "
+        "FROM metrics_ts "
+        "WHERE entity_id = %(country)s AND metric = %(metric)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM metrics_ts "
+        "WHERE entity_id = %(country)s AND metric = %(metric)s "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "country": country.upper(),
+        "metric": metric.value,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp))
+    return resp

--- a/app/api/routers/policy.py
+++ b/app/api/routers/policy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class Jurisdiction(str, Enum):
+    US = "US"
+    EU = "EU"
+    UK = "UK"
+
+
+class PolicySource(str, Enum):
+    federal_register = "federal_register"
+    eur_lex = "eur_lex"
+    uk_legislation = "uk_legislation"
+    ofac = "ofac"
+    eu_sanctions = "eu_sanctions"
+    uk_hmt = "uk_hmt"
+    un_sanctions = "un_sanctions"
+    bis_entity_list = "bis_entity_list"
+
+
+router = APIRouter(tags=["policy"])
+
+
+@router.get("/policy")
+async def get_policy_events(
+    jurisdiction: Jurisdiction = Query(...),
+    source: PolicySource | None = None,
+    q: str | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = f"policy:{jurisdiction.value}:{source.value if source else None}:{q}:{start}:{end}:{page.limit}:{page.offset}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT event_id, jurisdiction, source, published_at, title, summary, url, topics "
+        "FROM policy_events "
+        "WHERE jurisdiction = %(jurisdiction)s "
+        "AND (%(source)s IS NULL OR source = %(source)s) "
+        "AND (%(start)s IS NULL OR published_at >= %(start)s) "
+        "AND (%(end)s IS NULL OR published_at <= %(end)s) "
+        "AND (%(q)s IS NULL OR title ILIKE %(q_like)s OR summary ILIKE %(q_like)s) "
+        "ORDER BY published_at DESC LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM policy_events "
+        "WHERE jurisdiction = %(jurisdiction)s "
+        "AND (%(source)s IS NULL OR source = %(source)s) "
+        "AND (%(start)s IS NULL OR published_at >= %(start)s) "
+        "AND (%(end)s IS NULL OR published_at <= %(end)s) "
+        "AND (%(q)s IS NULL OR title ILIKE %(q_like)s OR summary ILIKE %(q_like)s)"
+    )
+    params = {
+        "jurisdiction": jurisdiction.value,
+        "source": source.value if source else None,
+        "q": q,
+        "q_like": f"%{q}%" if q else None,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=60)
+    return resp

--- a/app/api/routers/policy.py
+++ b/app/api/routers/policy.py
@@ -40,7 +40,11 @@ async def get_policy_events(
     end: datetime | None = None,
     page: Page = Depends(),
 ):
-    key = f"policy:{jurisdiction.value}:{source.value if source else None}:{q}:{start}:{end}:{page.limit}:{page.offset}"
+    key = (
+        f"policy:{jurisdiction.value}:"
+        f"{source.value if source else None}:"
+        f"{q}:{start}:{end}:{page.limit}:{page.offset}"
+    )
     cached = await cache.cache_get(key)
     if cached:
         if isinstance(cached, (bytes, str)):
@@ -48,7 +52,8 @@ async def get_policy_events(
         return cached
 
     sql = (
-        "SELECT event_id, jurisdiction, source, published_at, title, summary, url, topics "
+        "SELECT event_id, jurisdiction, source, published_at, title, summary, url, "
+        "topics "
         "FROM policy_events "
         "WHERE jurisdiction = %(jurisdiction)s "
         "AND (%(source)s IS NULL OR source = %(source)s) "

--- a/app/api/routers/ports.py
+++ b/app/api/routers/ports.py
@@ -30,7 +30,8 @@ async def get_port_series(
     page: Page = Depends(),
 ):
     key = (
-        f"port_series:{port_id}:{vessel_class.value}:{start}:{end}:{page.limit}:{page.offset}"
+        f"port_series:{port_id}:{vessel_class.value}:{start}:{end}:"
+        f"{page.limit}:{page.offset}"
     )
     cached = await cache.cache_get(key)
     if cached:
@@ -39,7 +40,8 @@ async def get_port_series(
         return cached
 
     sql = (
-        "SELECT port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
+        "SELECT port_id, vessel_class, ts, congestion, waiting_time, "
+        "arrivals, departures "
         "FROM port_congestion_ts "
         "WHERE port_id = %(port_id)s "
         "AND (%(vessel_class)s = 'all' OR vessel_class = %(vessel_class)s) "
@@ -80,15 +82,18 @@ async def get_port_snapshot(port_id: str, vessel_class: VesselClass = VesselClas
 
     if vessel_class == VesselClass.all:
         sql = (
-            "SELECT DISTINCT ON (vessel_class) port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
+            "SELECT DISTINCT ON (vessel_class) port_id, vessel_class, ts, "
+            "congestion, waiting_time, arrivals, departures "
             "FROM port_congestion_ts WHERE port_id = %(port_id)s "
             "ORDER BY vessel_class, ts DESC"
         )
         params = {"port_id": port_id}
     else:
         sql = (
-            "SELECT port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
-            "FROM port_congestion_ts WHERE port_id = %(port_id)s AND vessel_class = %(vessel_class)s "
+            "SELECT port_id, vessel_class, ts, congestion, waiting_time, "
+            "arrivals, departures "
+            "FROM port_congestion_ts WHERE port_id = %(port_id)s "
+            "AND vessel_class = %(vessel_class)s "
             "ORDER BY ts DESC LIMIT 1"
         )
         params = {"port_id": port_id, "vessel_class": vessel_class.value}

--- a/app/api/routers/ports.py
+++ b/app/api/routers/ports.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+
+from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class VesselClass(str, Enum):
+    container = "container"
+    tanker = "tanker"
+    bulk = "bulk"
+    all = "all"
+
+
+router = APIRouter(tags=["logistics"])
+
+
+@router.get("/logistics/ports/series")
+async def get_port_series(
+    port_id: str,
+    vessel_class: VesselClass = VesselClass.all,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    page: Page = Depends(),
+):
+    key = (
+        f"port_series:{port_id}:{vessel_class.value}:{start}:{end}:{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
+        "FROM port_congestion_ts "
+        "WHERE port_id = %(port_id)s "
+        "AND (%(vessel_class)s = 'all' OR vessel_class = %(vessel_class)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s) "
+        "ORDER BY ts LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM port_congestion_ts "
+        "WHERE port_id = %(port_id)s "
+        "AND (%(vessel_class)s = 'all' OR vessel_class = %(vessel_class)s) "
+        "AND (%(start)s IS NULL OR ts >= %(start)s) "
+        "AND (%(end)s IS NULL OR ts <= %(end)s)"
+    )
+    params = {
+        "port_id": port_id,
+        "vessel_class": vessel_class.value,
+        "start": start,
+        "end": end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp
+
+
+@router.get("/logistics/ports/snapshot")
+async def get_port_snapshot(port_id: str, vessel_class: VesselClass = VesselClass.all):
+    key = f"port_snapshot:{port_id}:{vessel_class.value}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    if vessel_class == VesselClass.all:
+        sql = (
+            "SELECT DISTINCT ON (vessel_class) port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
+            "FROM port_congestion_ts WHERE port_id = %(port_id)s "
+            "ORDER BY vessel_class, ts DESC"
+        )
+        params = {"port_id": port_id}
+    else:
+        sql = (
+            "SELECT port_id, vessel_class, ts, congestion, waiting_time, arrivals, departures "
+            "FROM port_congestion_ts WHERE port_id = %(port_id)s AND vessel_class = %(vessel_class)s "
+            "ORDER BY ts DESC LIMIT 1"
+        )
+        params = {"port_id": port_id, "vessel_class": vessel_class.value}
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    resp = {"data": rows}
+    await cache.cache_set(key, json.dumps(resp), ttl=15)
+    return resp
+
+
+@router.get("/logistics/ports/ref")
+async def get_port_ref(port_id: str | None = None):
+    sql = (
+        "SELECT port_id, name, country FROM ref_ports "
+        "WHERE (%(port_id)s IS NULL OR port_id = %(port_id)s)"
+    )
+    params = {"port_id": port_id}
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    return {"data": rows}

--- a/app/api/routers/trade.py
+++ b/app/api/routers/trade.py
@@ -40,7 +40,8 @@ async def get_trade_flows(
         return cached
 
     sql = (
-        "SELECT reporter_iso2, partner_iso2, hs_code, flow, period, value_usd, quantity, quantity_unit "
+        "SELECT reporter_iso2, partner_iso2, hs_code, flow, period, value_usd, "
+        "quantity, quantity_unit "
         "FROM trade_flows "
         "WHERE reporter_iso2 = %(reporter)s "
         "AND (%(partner)s IS NULL OR partner_iso2 = %(partner)s) "

--- a/app/api/routers/trade.py
+++ b/app/api/routers/trade.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.common import Page
+from app.core import cache, db
+
+
+class TradeFlow(str, Enum):
+    import_ = "import"
+    export = "export"
+    all = "all"
+
+
+router = APIRouter(tags=["logistics"])
+
+
+@router.get("/logistics/trade")
+async def get_trade_flows(
+    reporter: str = Query(..., min_length=2, max_length=2),
+    partner: str | None = Query(None, min_length=2, max_length=5),
+    hs: str | None = Query(None, min_length=2, max_length=6),
+    flow: TradeFlow = TradeFlow.all,
+    period_start: str | None = Query(None, min_length=6, max_length=6),
+    period_end: str | None = Query(None, min_length=6, max_length=6),
+    page: Page = Depends(),
+):
+    key = (
+        f"trade:{reporter}:{partner}:{hs}:{flow.value}:{period_start}:{period_end}:"
+        f"{page.limit}:{page.offset}"
+    )
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT reporter_iso2, partner_iso2, hs_code, flow, period, value_usd, quantity, quantity_unit "
+        "FROM trade_flows "
+        "WHERE reporter_iso2 = %(reporter)s "
+        "AND (%(partner)s IS NULL OR partner_iso2 = %(partner)s) "
+        "AND (%(flow)s = 'all' OR flow = %(flow)s) "
+        "AND (%(hs)s IS NULL OR hs_code LIKE %(hs_like)s) "
+        "AND (%(ps)s IS NULL OR period >= %(ps)s) "
+        "AND (%(pe)s IS NULL OR period <= %(pe)s) "
+        "ORDER BY period LIMIT %(limit)s OFFSET %(offset)s"
+    )
+    count_sql = (
+        "SELECT COUNT(*) as count FROM trade_flows "
+        "WHERE reporter_iso2 = %(reporter)s "
+        "AND (%(partner)s IS NULL OR partner_iso2 = %(partner)s) "
+        "AND (%(flow)s = 'all' OR flow = %(flow)s) "
+        "AND (%(hs)s IS NULL OR hs_code LIKE %(hs_like)s) "
+        "AND (%(ps)s IS NULL OR period >= %(ps)s) "
+        "AND (%(pe)s IS NULL OR period <= %(pe)s)"
+    )
+    params = {
+        "reporter": reporter.upper(),
+        "partner": partner.upper() if partner else None,
+        "hs": hs,
+        "hs_like": f"{hs}%" if hs else None,
+        "flow": flow.value,
+        "ps": period_start,
+        "pe": period_end,
+        "limit": page.limit,
+        "offset": page.offset,
+    }
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    count_row = await run_in_threadpool(db.fetch_one, count_sql, params)
+    resp = {"data": rows, "count": count_row.get("count", 0) if count_row else 0}
+    await cache.cache_set(key, json.dumps(resp), ttl=30)
+    return resp

--- a/app/api/routers/v1.py
+++ b/app/api/routers/v1.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from . import (
+    macro,
+    rates,
+    fx,
+    commodities,
+    policy,
+    cb,
+    geo,
+    trade,
+    ports,
+    chokepoints,
+    assets,
+)
+
+router = APIRouter(prefix="/v1")
+router.include_router(macro.router)
+router.include_router(rates.router)
+router.include_router(fx.router)
+router.include_router(commodities.router)
+router.include_router(policy.router)
+router.include_router(cb.router)
+router.include_router(geo.router)
+router.include_router(trade.router)
+router.include_router(ports.router)
+router.include_router(chokepoints.router)
+router.include_router(assets.router)

--- a/app/api/routers/v1.py
+++ b/app/api/routers/v1.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from . import (
-    macro,
-    rates,
-    fx,
-    commodities,
-    policy,
-    cb,
-    geo,
-    trade,
-    ports,
-    chokepoints,
     assets,
+    cb,
+    chokepoints,
+    commodities,
+    fx,
+    geo,
+    macro,
+    policy,
+    ports,
+    rates,
+    trade,
 )
 
 router = APIRouter(prefix="/v1")

--- a/app/api/schemas/common.py
+++ b/app/api/schemas/common.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TimeWindow(BaseModel):
+    start: datetime | None = None
+    end: datetime | None = None
+
+
+class Page(BaseModel):
+    limit: int = Field(100, ge=1, le=5000)
+    offset: int = Field(0, ge=0)
+
+
+class ErrorResp(BaseModel):
+    code: int
+    message: str

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from app.core.config import settings
 
 try:  # pragma: no cover - optional dependency
-    import redis.asyncio as redis
+    import redis.asyncio as redis  # type: ignore[import]
 except Exception:  # pragma: no cover - fallback
     redis = None  # type: ignore
 

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+from app.core.config import settings
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover - fallback
+    redis = None  # type: ignore
+
+
+class LocalCache:
+    def __init__(self) -> None:
+        self._store: Dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        item = self._store.get(key)
+        if not item:
+            return None
+        exp, value = item
+        if exp < time.time():
+            del self._store[key]
+            return None
+        return value
+
+    def set(self, key: str, value: Any, ttl: int) -> None:
+        self._store[key] = (time.time() + ttl, value)
+
+
+_client: Any | None = None
+_local_cache = LocalCache()
+
+
+async def init_cache() -> None:
+    global _client
+    if settings.redis_dsn and redis is not None:
+        try:
+            _client = redis.from_url(settings.redis_dsn)
+            await _client.ping()
+            return
+        except Exception:  # pragma: no cover - fall back
+            _client = None
+    _client = None
+
+
+def close_cache() -> None:
+    global _client
+    if _client is not None:
+        try:
+            _client.close()  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover
+            pass
+        _client = None
+
+
+async def cache_get(key: str) -> Any | None:
+    if _client is not None:
+        return await _client.get(key)
+    return _local_cache.get(key)
+
+
+async def cache_set(key: str, value: Any, ttl: int = 30) -> None:
+    if _client is not None:
+        await _client.setex(key, ttl, value)
+    else:
+        _local_cache.set(key, value, ttl)

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+from psycopg2.pool import SimpleConnectionPool
+from psycopg2.extras import RealDictCursor
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_pool: SimpleConnectionPool | None = None
+
+
+def init_pool() -> None:
+    global _pool
+    if _pool is not None:
+        return
+    try:
+        _pool = SimpleConnectionPool(1, 5, dsn=settings.postgres_dsn)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to init DB pool: %s", exc)
+        _pool = None
+
+
+def close_pool() -> None:
+    global _pool
+    if _pool is not None:
+        _pool.closeall()
+        _pool = None
+
+
+def get_conn():
+    if _pool is None:  # pragma: no cover - defensive
+        raise RuntimeError("DB pool not initialized")
+    return _pool.getconn()
+
+
+def release_conn(conn) -> None:
+    if _pool is None:  # pragma: no cover - defensive
+        conn.close()
+        return
+    _pool.putconn(conn)
+
+
+def fetch_all(sql: str, params: Iterable[Any] | None = None) -> list[dict[str, Any]]:
+    conn = get_conn()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return list(rows)
+    finally:
+        release_conn(conn)
+
+
+def fetch_one(sql: str, params: Iterable[Any] | None = None) -> dict[str, Any] | None:
+    conn = get_conn()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+        return dict(row) if row else None
+    finally:
+        release_conn(conn)

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterable
 
-from psycopg2.pool import SimpleConnectionPool
 from psycopg2.extras import RealDictCursor
+from psycopg2.pool import SimpleConnectionPool
 
 from app.core.config import settings
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,8 +6,10 @@ from fastapi import Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.deps import rate_limit
-from app.api.routers import auth, datasources, health, jobs
+from app.api.routers import auth, datasources, health, jobs, v1
 from app.core.config import settings
+from app.core import db
+from app.core import cache
 from app.core.logging import configure_logging
 from app.core.telemetry import metrics_middleware
 from app.core.telemetry import router as telemetry_router
@@ -27,6 +29,7 @@ app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(datasources.router)
 app.include_router(jobs.router)
+app.include_router(v1.router)
 app.include_router(telemetry_router)
 
 app.middleware("http")(metrics_middleware)
@@ -38,6 +41,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    db.init_pool()
+    await cache.init_cache()
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    db.close_pool()
+    cache.close_cache()
 
 
 @app.middleware("http")  # type: ignore[misc]

--- a/app/main.py
+++ b/app/main.py
@@ -7,9 +7,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.deps import rate_limit
 from app.api.routers import auth, datasources, health, jobs, v1
+from app.core import cache, db
 from app.core.config import settings
-from app.core import db
-from app.core import cache
 from app.core.logging import configure_logging
 from app.core.telemetry import metrics_middleware
 from app.core.telemetry import router as telemetry_router

--- a/ingestion/registry/data_registry.yaml
+++ b/ingestion/registry/data_registry.yaml
@@ -1,3 +1,4 @@
+# Registry of ingestion datasets spanning central bank, policy, macro, logistics, geopolitics, commodities, and US assets.
 datasets:
   fed_rss:
     enabled: true
@@ -71,6 +72,51 @@ datasets:
     conflict_keys: [source, source_id]
     mapper: policy.map_bis_entity
 
+  eu_sanctions:
+    enabled: true
+    adapter: file_scraper
+    url: https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content
+    cadence: daily
+    target_table: policy_events
+    conflict_keys: [source, source_id]
+    mapper: policy.map_sanction_update
+
+  uk_hmt_sanctions:
+    enabled: true
+    adapter: file_scraper
+    url: https://ofsistorage.blob.core.windows.net/publishlive/ConList.csv
+    cadence: daily
+    target_table: policy_events
+    conflict_keys: [source, source_id]
+    mapper: policy.map_sanction_update
+
+  un_sanctions:
+    enabled: true
+    adapter: file_scraper
+    url: https://scsanctions.un.org/consolidated
+    cadence: daily
+    target_table: policy_events
+    conflict_keys: [source, source_id]
+    mapper: policy.map_sanction_update
+
+  cbp_csms:
+    enabled: true
+    adapter: file_scraper
+    url: https://www.cbp.gov/trade/automated/cargo-systems-messaging-service-csms
+    cadence: daily
+    target_table: policy_events
+    conflict_keys: [source, source_id]
+    mapper: policy.map_policy_event
+
+  ustr_press:
+    enabled: true
+    adapter: file_scraper
+    url: https://ustr.gov/about-us/policy-offices/press-office/press-releases
+    cadence: daily
+    target_table: policy_events
+    conflict_keys: [source, source_id]
+    mapper: policy.map_policy_event
+
   world_bank:
     enabled: true
     adapter: rest_json
@@ -98,7 +144,34 @@ datasets:
     conflict_keys: [series_id, ts]
     mapper: macro.map_imf_ifs
 
+  bis_policy_rates:
+    enabled: true
+    adapter: file_scraper
+    url: https://www.bis.org/statistics/cbpol.csv
+    cadence: monthly
+    target_table: metrics_ts
+    conflict_keys: [series_id, ts]
+    mapper: macro.map_bis_policy_rate
+
   fred_rates:
+    enabled: true
+    adapter: rest_json
+    url: https://api.stlouisfed.org/fred/series/observations
+    cadence: daily
+    target_table: metrics_ts
+    conflict_keys: [series_id, ts]
+    mapper: macro.map_fred_series
+
+  fred_fx:
+    enabled: true
+    adapter: rest_json
+    url: https://api.stlouisfed.org/fred/series/observations
+    cadence: daily
+    target_table: metrics_ts
+    conflict_keys: [series_id, ts]
+    mapper: macro.map_fred_series
+
+  fred_extras:
     enabled: true
     adapter: rest_json
     url: https://api.stlouisfed.org/fred/series/observations
@@ -111,6 +184,20 @@ datasets:
     enabled: true
     adapter: rest_json
     url: https://comtradeapi.worldbank.org/v1/get
+    cadence: monthly
+    target_table: trade_flows
+    conflict_keys:
+      - reporter_iso2
+      - partner_iso2
+      - hs_code
+      - flow
+      - period
+    mapper: logistics.map_trade_flow
+
+  us_census_trade:
+    enabled: true
+    adapter: rest_json
+    url: https://api.census.gov/data/timeseries/intltrade/exports/hs
     cadence: monthly
     target_table: trade_flows
     conflict_keys:
@@ -138,6 +225,24 @@ datasets:
     target_table: ais_raw
     conflict_keys: [msg_id]
     mapper: logistics.map_ais_raw
+
+  pca_advisories:
+    enabled: true
+    adapter: file_scraper
+    url: https://pancanal.com/en/advisories/
+    cadence: daily
+    target_table: geo_events
+    conflict_keys: [source, source_id]
+    mapper: logistics.map_pca_advisory
+
+  nws_alerts:
+    enabled: true
+    adapter: rest_json
+    url: https://api.weather.gov/alerts
+    cadence: hourly
+    target_table: geo_events
+    conflict_keys: [source, source_id]
+    mapper: logistics.map_nws_alert
 
   gdelt_events:
     enabled: true

--- a/ingestion/tests/api/test_assets.py
+++ b/ingestion/tests/api/test_assets.py
@@ -13,11 +13,14 @@ client = TestClient(app)
 @patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
-def test_get_asset_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_asset_prices(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "close": 100.0}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "close": 100.0}]
     fetch_one.return_value = {"count": 1}
     resp = client.get("/v1/assets/prices", params={"symbol": "AAPL"})
     assert resp.status_code == 200
@@ -30,11 +33,14 @@ def test_get_asset_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set:
 @patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
-def test_get_index_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_index_prices(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 4000.0}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 4000.0}]
     fetch_one.return_value = {"count": 1}
     resp = client.get("/v1/assets/indices", params={"index_symbol": "SPX"})
     assert resp.status_code == 200
@@ -47,11 +53,14 @@ def test_get_index_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set:
 @patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
-def test_get_fundamentals(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_fundamentals(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 10.0, "unit": "USD"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 10.0, "unit": "USD"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get(
         "/v1/assets/fundamentals",
@@ -67,7 +76,12 @@ def test_get_fundamentals(fetch_all: MagicMock, fetch_one: MagicMock, cache_set:
 @patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
-def test_get_earnings_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_earnings_events(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {"cik": "0000320193", "ticker": "AAPL", "ts": "2024-01-01", "headline": "Q1"}

--- a/ingestion/tests/api/test_assets.py
+++ b/ingestion/tests/api/test_assets.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.assets.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
+def test_get_asset_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "close": 100.0}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/assets/prices", params={"symbol": "AAPL"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.assets.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
+def test_get_index_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 4000.0}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/assets/indices", params={"index_symbol": "SPX"})
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["value"] == 4000.0
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.assets.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
+def test_get_fundamentals(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 10.0, "unit": "USD"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/assets/fundamentals",
+        params={"cik": "0000320193", "fact": "Assets"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.assets.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.assets.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.assets.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.assets.db.fetch_all", new_callable=MagicMock)
+def test_get_earnings_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"cik": "0000320193", "ticker": "AAPL", "ts": "2024-01-01", "headline": "Q1"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/assets/earnings",
+        params={"cik": "0000320193"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["ticker"] == "AAPL"
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/ingestion/transforms/policy.py
+++ b/ingestion/transforms/policy.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Iterator
 
 
 def _classify_statement(title: str, url: str) -> str:
+    """Best-effort classification of central bank communications."""
     t = f"{title} {url}".lower()
     if "minutes" in t:
         return "minutes"
@@ -19,47 +20,109 @@ def _cb_name(source: str) -> str:
     return {"fed": "Fed", "ecb": "ECB", "boe": "BoE"}.get(source, source)
 
 
-def transform(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-    """Map policy-related records to ``cb_statements`` or ``policy_events``."""
+def map_cb_statement(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Transform central-bank RSS records into ``cb_statements`` rows."""
+
+    for rec in records:
+        url = rec.get("url", "")
+        title = rec.get("title", "")
+        source = str(rec.get("source", ""))
+        yield {
+            "statement_id": hashlib.md5(url.encode()).hexdigest(),
+            "central_bank": _cb_name(source),
+            "published_at": rec.get("published_at"),
+            "type": _classify_statement(title, url),
+            "title": title,
+            "url": url,
+            "text_excerpt": rec.get("summary"),
+            "hawkish_dovish_score": None,
+            "next_meeting_date": None,
+            "raw": rec,
+        }
+
+
+def map_policy_event(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Generic mapper for regulatory or policy announcements."""
 
     for rec in records:
         source = str(rec.get("source", ""))
-        if source in {"fed", "ecb", "boe"}:
-            url = rec.get("url", "")
-            title = rec.get("title", "")
-            yield {
-                "statement_id": hashlib.md5(url.encode()).hexdigest(),
-                "central_bank": _cb_name(source),
-                "published_at": rec.get("published_at"),
-                "type": _classify_statement(title, url),
-                "title": title,
-                "url": url,
-                "text_excerpt": rec.get("summary"),
-                "hawkish_dovish_score": None,
-                "next_meeting_date": None,
-                "raw": rec,
-            }
-            continue
-
-        # policy events
         jurisdiction = {"federal_register": "US", "eurlex": "EU", "uk": "UK"}.get(
             source
         )
-        if jurisdiction:
-            src_id = str(rec.get("id"))
-            yield {
-                "event_id": f"{source}:{src_id}",
-                "jurisdiction": jurisdiction,
-                "source": source,
-                "source_id": src_id,
-                "published_at": rec.get("published_at"),
-                "title": rec.get("title"),
-                "summary": rec.get("summary"),
-                "url": rec.get("url"),
-                "topics": None,
-                "affected_countries": None,
-                "affected_sectors": None,
-                "affected_entities": None,
-                "severity": None,
-                "raw": rec,
-            }
+        src_id = str(rec.get("id", "")) or hashlib.md5(str(rec).encode()).hexdigest()
+        yield {
+            "event_id": f"{source}:{src_id}",
+            "jurisdiction": jurisdiction,
+            "source": source,
+            "source_id": src_id,
+            "published_at": rec.get("published_at"),
+            "title": rec.get("title"),
+            "summary": rec.get("summary"),
+            "url": rec.get("url"),
+            "topics": None,
+            "affected_countries": None,
+            "affected_sectors": None,
+            "affected_entities": None,
+            "severity": None,
+            "raw": rec,
+        }
+
+
+def map_sanction_update(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Map sanction-list rows into ``policy_events`` entries."""
+
+    for rec in records:
+        name = str(rec.get("name", rec.get("entity", "unknown")))
+        src = str(rec.get("source", "sanctions"))
+        src_id = str(rec.get("id", hashlib.md5(name.encode()).hexdigest()))
+        yield {
+            "event_id": f"{src}:{src_id}",
+            "jurisdiction": rec.get("jurisdiction"),
+            "source": src,
+            "source_id": src_id,
+            "published_at": rec.get("published_at"),
+            "title": name,
+            "summary": rec.get("program") or rec.get("remarks"),
+            "url": rec.get("url"),
+            "topics": None,
+            "affected_countries": rec.get("country"),
+            "affected_sectors": None,
+            "affected_entities": name,
+            "severity": None,
+            "raw": rec,
+        }
+
+
+def map_bis_entity(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Specialised mapper for BIS Entity List updates."""
+
+    for rec in records:
+        name = str(rec.get("name", ""))
+        src_id = str(rec.get("id", hashlib.md5(name.encode()).hexdigest()))
+        yield {
+            "event_id": f"bis:{src_id}",
+            "jurisdiction": "US",
+            "source": "bis",
+            "source_id": src_id,
+            "published_at": rec.get("published_at"),
+            "title": name,
+            "summary": rec.get("summary"),
+            "url": rec.get("url"),
+            "topics": None,
+            "affected_countries": rec.get("country"),
+            "affected_sectors": None,
+            "affected_entities": name,
+            "severity": None,
+            "raw": rec,
+        }
+
+
+# Backwards compatibility for older registry entries
+def transform(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:  # pragma: no cover
+    """Legacy wrapper that auto-detects record type."""
+    for rec in records:
+        src = str(rec.get("source", ""))
+        if src in {"fed", "ecb", "boe"}:
+            yield from map_cb_statement([rec])
+        else:
+            yield from map_policy_event([rec])

--- a/ingestion/transforms/policy.py
+++ b/ingestion/transforms/policy.py
@@ -118,7 +118,9 @@ def map_bis_entity(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]
 
 
 # Backwards compatibility for older registry entries
-def transform(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:  # pragma: no cover
+def transform(
+    records: Iterable[dict[str, Any]],
+) -> Iterator[dict[str, Any]]:  # pragma: no cover
     """Legacy wrapper that auto-detects record type."""
     for rec in records:
         src = str(rec.get("source", ""))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -q --cov=ingestion --cov-report=term-missing --cov-fail-under=0
+addopts = -q --cov=app --cov-fail-under=80
 asyncio_mode = auto

--- a/tests/api/test_cb.py
+++ b/tests/api/test_cb.py
@@ -13,7 +13,12 @@ client = TestClient(app)
 @patch("app.api.routers.cb.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.cb.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.cb.db.fetch_all", new_callable=MagicMock)
-def test_get_cb_statements(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_cb_statements(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {

--- a/tests/api/test_cb.py
+++ b/tests/api/test_cb.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.cb.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.cb.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.cb.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.cb.db.fetch_all", new_callable=MagicMock)
+def test_get_cb_statements(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "statement_id": 1,
+            "central_bank": "FED",
+            "type": "decision",
+            "published_at": "2024-01-01",
+            "title": "Rate Decision",
+            "url": "http://example.com",
+            "hawkish_dovish_score": None,
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/cb", params={"bank": "FED", "type": "decision"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_commodities.py
+++ b/tests/api/test_commodities.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.commodities.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.commodities.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.commodities.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.commodities.db.fetch_all", new_callable=MagicMock)
+def test_get_commodity_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "price": 75.0, "unit": "USD/bbl"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/commodities", params={"code": "WTI"})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": [{"ts": "2024-01-01", "price": 75.0, "unit": "USD/bbl"}],
+        "count": 1,
+    }
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.commodities.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.commodities.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.commodities.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.commodities.db.fetch_all", new_callable=MagicMock)
+def test_get_bdi_index(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 1000.0, "source": "test"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/freight/bdi")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_commodities.py
+++ b/tests/api/test_commodities.py
@@ -13,11 +13,14 @@ client = TestClient(app)
 @patch("app.api.routers.commodities.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.commodities.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.commodities.db.fetch_all", new_callable=MagicMock)
-def test_get_commodity_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_commodity_prices(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "price": 75.0, "unit": "USD/bbl"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "price": 75.0, "unit": "USD/bbl"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get("/v1/commodities", params={"code": "WTI"})
     assert resp.status_code == 200
@@ -33,11 +36,14 @@ def test_get_commodity_prices(fetch_all: MagicMock, fetch_one: MagicMock, cache_
 @patch("app.api.routers.commodities.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.commodities.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.commodities.db.fetch_all", new_callable=MagicMock)
-def test_get_bdi_index(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_bdi_index(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 1000.0, "source": "test"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 1000.0, "source": "test"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get("/v1/freight/bdi")
     assert resp.status_code == 200

--- a/tests/api/test_fx.py
+++ b/tests/api/test_fx.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.fx.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.fx.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.fx.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.fx.db.fetch_all", new_callable=MagicMock)
+def test_get_fx_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 1.1, "unit": "USD/EUR"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/fx",
+        params={"pair": "usd_eur"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["unit"] == "USD/EUR"
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_fx.py
+++ b/tests/api/test_fx.py
@@ -13,11 +13,14 @@ client = TestClient(app)
 @patch("app.api.routers.fx.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.fx.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.fx.db.fetch_all", new_callable=MagicMock)
-def test_get_fx_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_fx_series(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 1.1, "unit": "USD/EUR"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 1.1, "unit": "USD/EUR"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get(
         "/v1/fx",

--- a/tests/api/test_geo.py
+++ b/tests/api/test_geo.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.geo.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.geo.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.geo.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.geo.db.fetch_all", new_callable=MagicMock)
+def test_get_geo_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "source": "gdelt_events",
+            "source_id": "1",
+            "ts": "2024-01-01T00:00:00",
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/geo/events", params={"country": "US"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.geo.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.geo.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.geo.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.geo.db.fetch_all", new_callable=MagicMock)
+def test_get_geo_mentions(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"event_source_id": "1", "ts": "2024-01-01T00:00:00"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/geo/mentions", params={"event_source_id": "1"})
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["event_source_id"] == "1"
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_geo.py
+++ b/tests/api/test_geo.py
@@ -13,7 +13,12 @@ client = TestClient(app)
 @patch("app.api.routers.geo.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.geo.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.geo.db.fetch_all", new_callable=MagicMock)
-def test_get_geo_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_geo_events(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {
@@ -34,11 +39,14 @@ def test_get_geo_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: A
 @patch("app.api.routers.geo.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.geo.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.geo.db.fetch_all", new_callable=MagicMock)
-def test_get_geo_mentions(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_geo_mentions(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"event_source_id": "1", "ts": "2024-01-01T00:00:00"}
-    ]
+    fetch_all.return_value = [{"event_source_id": "1", "ts": "2024-01-01T00:00:00"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get("/v1/geo/mentions", params={"event_source_id": "1"})
     assert resp.status_code == 200

--- a/tests/api/test_macro.py
+++ b/tests/api/test_macro.py
@@ -13,11 +13,14 @@ client = TestClient(app)
 @patch("app.api.routers.macro.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.macro.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.macro.db.fetch_all", new_callable=MagicMock)
-def test_get_macro_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_macro_series(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 100.0, "unit": "USD"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 100.0, "unit": "USD"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get(
         "/v1/macro",

--- a/tests/api/test_macro.py
+++ b/tests/api/test_macro.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.macro.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.macro.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.macro.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.macro.db.fetch_all", new_callable=MagicMock)
+def test_get_macro_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 100.0, "unit": "USD"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/macro",
+        params={"country": "USA", "metric": "gdp_current_usd"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": [{"ts": "2024-01-01", "value": 100.0, "unit": "USD"}],
+        "count": 1,
+    }
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_policy.py
+++ b/tests/api/test_policy.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.policy.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.policy.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.policy.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.policy.db.fetch_all", new_callable=MagicMock)
+def test_get_policy_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "event_id": 1,
+            "jurisdiction": "US",
+            "source": "ofac",
+            "published_at": "2024-01-01",
+            "title": "Sanctions Update",
+            "summary": "Details",
+            "url": "http://example.com",
+            "topics": ["sanctions"],
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get("/v1/policy", params={"jurisdiction": "US"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_policy.py
+++ b/tests/api/test_policy.py
@@ -13,7 +13,12 @@ client = TestClient(app)
 @patch("app.api.routers.policy.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.policy.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.policy.db.fetch_all", new_callable=MagicMock)
-def test_get_policy_events(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_policy_events(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {

--- a/tests/api/test_ports.py
+++ b/tests/api/test_ports.py
@@ -13,7 +13,12 @@ client = TestClient(app)
 @patch("app.api.routers.ports.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.ports.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.ports.db.fetch_all", new_callable=MagicMock)
-def test_get_port_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_port_series(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {
@@ -37,7 +42,9 @@ def test_get_port_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: 
 @patch("app.api.routers.ports.cache.cache_get", new_callable=AsyncMock)
 @patch("app.api.routers.ports.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.ports.db.fetch_all", new_callable=MagicMock)
-def test_get_port_snapshot(fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_port_snapshot(
+    fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {
@@ -60,7 +67,12 @@ def test_get_port_snapshot(fetch_all: MagicMock, cache_set: AsyncMock, cache_get
 @patch("app.api.routers.chokepoints.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.chokepoints.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.chokepoints.db.fetch_all", new_callable=MagicMock)
-def test_get_chokepoint_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_chokepoint_series(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {
@@ -84,7 +96,9 @@ def test_get_chokepoint_series(fetch_all: MagicMock, fetch_one: MagicMock, cache
 @patch("app.api.routers.chokepoints.cache.cache_get", new_callable=AsyncMock)
 @patch("app.api.routers.chokepoints.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.chokepoints.db.fetch_all", new_callable=MagicMock)
-def test_get_chokepoint_snapshot(fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_chokepoint_snapshot(
+    fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {

--- a/tests/api/test_ports.py
+++ b/tests/api/test_ports.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.ports.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.ports.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.ports.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.ports.db.fetch_all", new_callable=MagicMock)
+def test_get_port_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "port_id": "LA",
+            "vessel_class": "container",
+            "ts": "2024-01-01T00:00:00",
+            "congestion": 1.0,
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/logistics/ports/series",
+        params={"port_id": "LA", "vessel_class": "container"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.ports.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.ports.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.ports.db.fetch_all", new_callable=MagicMock)
+def test_get_port_snapshot(fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "port_id": "LA",
+            "vessel_class": "container",
+            "ts": "2024-01-01T00:00:00",
+            "congestion": 1.0,
+        }
+    ]
+    resp = client.get(
+        "/v1/logistics/ports/snapshot",
+        params={"port_id": "LA", "vessel_class": "container"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["port_id"] == "LA"
+    fetch_all.assert_called_once()
+
+
+@patch("app.api.routers.chokepoints.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.chokepoints.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.chokepoints.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.chokepoints.db.fetch_all", new_callable=MagicMock)
+def test_get_chokepoint_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "chokepoint_id": "pc",
+            "vessel_class": "tanker",
+            "ts": "2024-01-01T00:00:00",
+            "delay_hours": 5.0,
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/logistics/chokepoints/series",
+        params={"chokepoint_id": "pc", "vessel_class": "tanker"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.chokepoints.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.chokepoints.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.chokepoints.db.fetch_all", new_callable=MagicMock)
+def test_get_chokepoint_snapshot(fetch_all: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "chokepoint_id": "pc",
+            "vessel_class": "tanker",
+            "ts": "2024-01-01T00:00:00",
+            "delay_hours": 5.0,
+        }
+    ]
+    resp = client.get(
+        "/v1/logistics/chokepoints/snapshot",
+        params={"chokepoint_id": "pc", "vessel_class": "tanker"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["chokepoint_id"] == "pc"
+    fetch_all.assert_called_once()

--- a/tests/api/test_rates.py
+++ b/tests/api/test_rates.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.rates.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.rates.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.rates.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.rates.db.fetch_all", new_callable=MagicMock)
+def test_get_rates_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"ts": "2024-01-01", "value": 4.0, "unit": "percent"}
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/rates",
+        params={"series": "us_10y_yield"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    assert resp.json()["data"][0]["value"] == 4.0
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()

--- a/tests/api/test_rates.py
+++ b/tests/api/test_rates.py
@@ -13,11 +13,14 @@ client = TestClient(app)
 @patch("app.api.routers.rates.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.rates.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.rates.db.fetch_all", new_callable=MagicMock)
-def test_get_rates_series(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_rates_series(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
-    fetch_all.return_value = [
-        {"ts": "2024-01-01", "value": 4.0, "unit": "percent"}
-    ]
+    fetch_all.return_value = [{"ts": "2024-01-01", "value": 4.0, "unit": "percent"}]
     fetch_one.return_value = {"count": 1}
     resp = client.get(
         "/v1/rates",

--- a/tests/api/test_trade.py
+++ b/tests/api/test_trade.py
@@ -13,7 +13,12 @@ client = TestClient(app)
 @patch("app.api.routers.trade.cache.cache_set", new_callable=AsyncMock)
 @patch("app.api.routers.trade.db.fetch_one", new_callable=MagicMock)
 @patch("app.api.routers.trade.db.fetch_all", new_callable=MagicMock)
-def test_get_trade_flows(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+def test_get_trade_flows(
+    fetch_all: MagicMock,
+    fetch_one: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
     cache_get.return_value = None
     fetch_all.return_value = [
         {

--- a/tests/api/test_trade.py
+++ b/tests/api/test_trade.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.trade.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.trade.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.trade.db.fetch_one", new_callable=MagicMock)
+@patch("app.api.routers.trade.db.fetch_all", new_callable=MagicMock)
+def test_get_trade_flows(fetch_all: MagicMock, fetch_one: MagicMock, cache_set: AsyncMock, cache_get: AsyncMock) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {
+            "reporter_iso2": "US",
+            "partner_iso2": "CN",
+            "hs_code": "01",
+            "flow": "import",
+            "period": "202401",
+            "value_usd": 100.0,
+        }
+    ]
+    fetch_one.return_value = {"count": 1}
+    resp = client.get(
+        "/v1/logistics/trade",
+        params={"reporter": "US", "partner": "CN", "hs": "01", "flow": "import"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["data"][0]["hs_code"] == "01"
+    fetch_all.assert_called_once()
+    fetch_one.assert_called_once()


### PR DESCRIPTION
## Summary
- add /geo events and mentions endpoints with configurable source filters and caching
- expose Comtrade-based trade flows with HS prefix filtering under /logistics/trade
- deliver AIS-derived port and chokepoint congestion metrics plus metadata lookups
- implement assets prices, indices, fundamentals, and earnings APIs with examples and coverage gate

## Testing
- `POSTGRES_DSN=postgresql://localhost MONGO_DSN=mongodb://localhost REDIS_DSN=redis://localhost SECRET_KEY=secret pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b5f722548323a73ac3b0de74d058