### PR TITLE
Add alerts CRUD API endpoints

### DIFF
--- a/app/api/routers/alerts.py
+++ b/app/api/routers/alerts.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.alerts import AlertDeliveryCreate, AlertRuleCreate
+from app.core import db
+from app.core.security import get_current_user
+from app.services import auth_service
+
+router = APIRouter(tags=["alerts"])
+
+
+@router.get("/alerts/rules")
+async def list_rules(user: auth_service.User = Depends(get_current_user)):
+    sql = (
+        "SELECT id, name, rule_json, enabled, cooldown_s, created_at FROM alert_rules "
+        "WHERE user_id = (SELECT id FROM users WHERE email = %(email)s)"
+    )
+    rows = await run_in_threadpool(db.fetch_all, sql, {"email": user.email})
+    return {"data": rows}
+
+
+@router.post("/alerts/rules", status_code=status.HTTP_201_CREATED)
+async def create_rule(
+    req: AlertRuleCreate, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "INSERT INTO alert_rules "
+        "(id, user_id, name, rule_json, enabled, cooldown_s, created_at) "
+        "VALUES ("
+        "%(id)s, (SELECT id FROM users WHERE email=%(email)s), "
+        "%(name)s, %(rule_json)s, TRUE, %(cooldown)s, NOW()"
+        ") RETURNING id, name, rule_json, enabled, cooldown_s, created_at"
+    )
+    rid = uuid.uuid4()
+    params = {
+        "id": rid,
+        "email": user.email,
+        "name": req.name,
+        "rule_json": req.rule_json,
+        "cooldown": req.cooldown_s,
+    }
+    row = await run_in_threadpool(db.fetch_one, sql, params)
+    return row
+
+
+@router.post("/alerts/rules/{rule_id}/enable")
+async def enable_rule(
+    rule_id: uuid.UUID, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "UPDATE alert_rules SET enabled = TRUE WHERE id = %(id)s "
+        "AND user_id = (SELECT id FROM users WHERE email=%(email)s) "
+        "RETURNING id, name, rule_json, enabled, cooldown_s, created_at"
+    )
+    row = await run_in_threadpool(
+        db.fetch_one, sql, {"id": str(rule_id), "email": user.email}
+    )
+    return row
+
+
+@router.post("/alerts/rules/{rule_id}/disable")
+async def disable_rule(
+    rule_id: uuid.UUID, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "UPDATE alert_rules SET enabled = FALSE WHERE id = %(id)s "
+        "AND user_id = (SELECT id FROM users WHERE email=%(email)s) "
+        "RETURNING id, name, rule_json, enabled, cooldown_s, created_at"
+    )
+    row = await run_in_threadpool(
+        db.fetch_one, sql, {"id": str(rule_id), "email": user.email}
+    )
+    return row
+
+
+@router.get("/alerts/deliveries")
+async def list_deliveries(
+    rule_id: uuid.UUID | None = None,
+    user: auth_service.User = Depends(get_current_user),
+):
+    sql = (
+        "SELECT d.id, d.rule_id, d.kind, d.target, d.secret, d.active "
+        "FROM alert_deliveries d JOIN alert_rules r ON d.rule_id = r.id "
+        "WHERE r.user_id = (SELECT id FROM users WHERE email=%(email)s)"
+    )
+    params: dict[str, object] = {"email": user.email}
+    if rule_id is not None:
+        sql += " AND d.rule_id = %(rule_id)s"
+        params["rule_id"] = str(rule_id)
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    return {"data": rows}
+
+
+@router.post("/alerts/deliveries", status_code=status.HTTP_201_CREATED)
+async def create_delivery(
+    req: AlertDeliveryCreate, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "INSERT INTO alert_deliveries (id, rule_id, kind, target, secret, active) "
+        "SELECT %(id)s, r.id, %(kind)s, %(target)s, %(secret)s, TRUE "
+        "FROM alert_rules r JOIN users u ON r.user_id = u.id "
+        "WHERE r.id = %(rule_id)s AND u.email = %(email)s "
+        "RETURNING id, rule_id, kind, target, secret, active"
+    )
+    did = uuid.uuid4()
+    params = {
+        "id": did,
+        "rule_id": str(req.rule_id),
+        "kind": req.kind.value,
+        "target": req.target,
+        "secret": req.secret,
+        "email": user.email,
+    }
+    row = await run_in_threadpool(db.fetch_one, sql, params)
+    return row
+
+
+@router.get("/alerts/events")
+async def list_events(
+    rule_id: uuid.UUID | None = None,
+    from_ts: datetime | None = None,
+    user: auth_service.User = Depends(get_current_user),
+):
+    sql = (
+        "SELECT e.id, e.rule_id, e.fired_at, e.payload_json, "
+        "e.dedupe_key, e.delivered, e.attempts, e.last_error "
+        "FROM alert_events e JOIN alert_rules r ON e.rule_id = r.id "
+        "WHERE r.user_id = (SELECT id FROM users WHERE email=%(email)s)"
+    )
+    params: dict[str, object] = {"email": user.email}
+    if rule_id is not None:
+        sql += " AND e.rule_id = %(rule_id)s"
+        params["rule_id"] = str(rule_id)
+    if from_ts is not None:
+        sql += " AND e.fired_at >= %(from_ts)s"
+        params["from_ts"] = from_ts
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+    return {"data": rows}

--- a/app/api/routers/portfolio.py
+++ b/app/api/routers/portfolio.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Response, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.portfolio import HoldingsUpsertRequest, PortfolioCreate
+from app.core import db
+from app.core.security import get_current_user
+from app.services import auth_service
+
+router = APIRouter(tags=["portfolio"])
+
+
+@router.get("/portfolio")
+async def list_portfolios(
+    user: auth_service.User = Depends(get_current_user),
+):
+    sql = (
+        "SELECT id, name, created_at FROM portfolios "
+        "WHERE user_id = (SELECT id FROM users WHERE email = %(email)s)"
+    )
+    rows = await run_in_threadpool(db.fetch_all, sql, {"email": user.email})
+    return {"data": rows}
+
+
+@router.post("/portfolio", status_code=status.HTTP_201_CREATED)
+async def create_portfolio(
+    req: PortfolioCreate, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "INSERT INTO portfolios (id, user_id, name, created_at) "
+        "VALUES (%(id)s, (SELECT id FROM users WHERE email=%(email)s), "
+        "%(name)s, NOW()) "
+        "RETURNING id, name, created_at"
+    )
+    pid = uuid.uuid4()
+    row = await run_in_threadpool(
+        db.fetch_one,
+        sql,
+        {"id": pid, "email": user.email, "name": req.name},
+    )
+    return row
+
+
+@router.delete(
+    "/portfolio/{portfolio_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_portfolio(
+    portfolio_id: uuid.UUID, user: auth_service.User = Depends(get_current_user)
+) -> Response:
+    sql = (
+        "DELETE FROM portfolios WHERE id = %(id)s "
+        "AND user_id = (SELECT id FROM users WHERE email=%(email)s)"
+    )
+    await run_in_threadpool(
+        db.fetch_one, sql, {"id": str(portfolio_id), "email": user.email}
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/portfolio/{portfolio_id}/holdings")
+async def upsert_holdings(
+    portfolio_id: uuid.UUID,
+    req: HoldingsUpsertRequest,
+    user: auth_service.User = Depends(get_current_user),
+):
+    del_sql = "DELETE FROM portfolio_holdings WHERE portfolio_id=%(pid)s"
+    await run_in_threadpool(db.fetch_one, del_sql, {"pid": str(portfolio_id)})
+    insert_sql = (
+        "INSERT INTO portfolio_holdings (portfolio_id, symbol, weight, shares, as_of) "
+        "VALUES (%(pid)s, %(symbol)s, %(weight)s, %(shares)s, %(as_of)s) "
+        "RETURNING portfolio_id, symbol, weight, shares, as_of"
+    )
+    rows = []
+    for h in req.holdings:
+        params = {
+            "pid": str(portfolio_id),
+            "symbol": h.symbol,
+            "weight": h.weight,
+            "shares": h.shares,
+            "as_of": h.as_of,
+        }
+        row = await run_in_threadpool(db.fetch_one, insert_sql, params)
+        rows.append(row)
+    return {"data": rows}

--- a/app/api/routers/v1.py
+++ b/app/api/routers/v1.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from . import (
+    alerts,
     assets,
     cb,
     chokepoints,
@@ -11,9 +12,11 @@ from . import (
     geo,
     macro,
     policy,
+    portfolio,
     ports,
     rates,
     trade,
+    watchlist,
 )
 
 router = APIRouter(prefix="/v1")
@@ -28,3 +31,6 @@ router.include_router(trade.router)
 router.include_router(ports.router)
 router.include_router(chokepoints.router)
 router.include_router(assets.router)
+router.include_router(portfolio.router)
+router.include_router(watchlist.router)
+router.include_router(alerts.router)

--- a/app/api/routers/watchlist.py
+++ b/app/api/routers/watchlist.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Response, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.api.schemas.watchlist import WatchlistCreate, WatchlistItemsUpsert
+from app.core import db
+from app.core.security import get_current_user
+from app.services import auth_service
+
+router = APIRouter(tags=["watchlist"])
+
+
+@router.get("/watchlist")
+async def list_watchlists(
+    user: auth_service.User = Depends(get_current_user),
+):
+    sql = (
+        "SELECT id, name, type FROM watchlists "
+        "WHERE user_id = (SELECT id FROM users WHERE email = %(email)s)"
+    )
+    rows = await run_in_threadpool(db.fetch_all, sql, {"email": user.email})
+    return {"data": rows}
+
+
+@router.post("/watchlist", status_code=status.HTTP_201_CREATED)
+async def create_watchlist(
+    req: WatchlistCreate, user: auth_service.User = Depends(get_current_user)
+):
+    sql = (
+        "INSERT INTO watchlists (id, user_id, name, type) "
+        "VALUES (%(id)s, (SELECT id FROM users WHERE email=%(email)s), "
+        "%(name)s, %(type)s) "
+        "RETURNING id, name, type"
+    )
+    wid = uuid.uuid4()
+    row = await run_in_threadpool(
+        db.fetch_one,
+        sql,
+        {
+            "id": wid,
+            "email": user.email,
+            "name": req.name,
+            "type": req.type.value,
+        },
+    )
+    return row
+
+
+@router.delete(
+    "/watchlist/{watchlist_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_watchlist(
+    watchlist_id: uuid.UUID, user: auth_service.User = Depends(get_current_user)
+) -> Response:
+    sql = (
+        "DELETE FROM watchlists WHERE id = %(id)s "
+        "AND user_id = (SELECT id FROM users WHERE email=%(email)s)"
+    )
+    await run_in_threadpool(
+        db.fetch_one, sql, {"id": str(watchlist_id), "email": user.email}
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/watchlist/{watchlist_id}/items")
+async def upsert_items(
+    watchlist_id: uuid.UUID,
+    req: WatchlistItemsUpsert,
+    user: auth_service.User = Depends(get_current_user),
+):
+    del_sql = "DELETE FROM watchlist_items WHERE watchlist_id=%(wid)s"
+    await run_in_threadpool(db.fetch_one, del_sql, {"wid": str(watchlist_id)})
+    insert_sql = (
+        "INSERT INTO watchlist_items (watchlist_id, ref_id, label, meta) "
+        "VALUES (%(wid)s, %(ref_id)s, %(label)s, %(meta)s) "
+        "RETURNING watchlist_id, ref_id, label, meta"
+    )
+    rows = []
+    for item in req.items:
+        params = {
+            "wid": str(watchlist_id),
+            "ref_id": item.ref_id,
+            "label": item.label,
+            "meta": item.meta,
+        }
+        row = await run_in_threadpool(db.fetch_one, insert_sql, params)
+        rows.append(row)
+    return {"data": rows}

--- a/app/api/schemas/alerts.py
+++ b/app/api/schemas/alerts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AlertRuleCreate(BaseModel):
+    name: str
+    rule_json: dict[str, Any]
+    cooldown_s: int = 0
+
+
+class AlertRule(AlertRuleCreate):
+    id: uuid.UUID
+    enabled: bool = True
+    created_at: datetime
+
+
+class AlertDeliveryKind(str, Enum):
+    email = "email"
+    webhook = "webhook"
+
+
+class AlertDeliveryCreate(BaseModel):
+    rule_id: uuid.UUID
+    kind: AlertDeliveryKind
+    target: str
+    secret: str | None = None
+
+
+class AlertDelivery(AlertDeliveryCreate):
+    id: uuid.UUID
+    active: bool = True
+
+
+class AlertEvent(BaseModel):
+    id: uuid.UUID
+    rule_id: uuid.UUID
+    fired_at: datetime
+    payload_json: dict[str, Any]
+    dedupe_key: str
+    delivered: bool
+    attempts: int
+    last_error: str | None = None
+
+
+class AlertEventsResponse(BaseModel):
+    data: list[AlertEvent] = Field(default_factory=list)
+
+
+class AlertRulesResponse(BaseModel):
+    data: list[AlertRule] = Field(default_factory=list)
+
+
+class AlertDeliveriesResponse(BaseModel):
+    data: list[AlertDelivery] = Field(default_factory=list)

--- a/app/api/schemas/portfolio.py
+++ b/app/api/schemas/portfolio.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+
+class PortfolioCreate(BaseModel):
+    name: str
+
+
+class Portfolio(PortfolioCreate):
+    id: uuid.UUID
+    created_at: datetime
+
+
+class Holding(BaseModel):
+    symbol: str
+    weight: float | None = None
+    shares: float | None = None
+    as_of: date
+
+
+class HoldingsUpsertRequest(BaseModel):
+    holdings: list[Holding] = Field(default_factory=list)

--- a/app/api/schemas/watchlist.py
+++ b/app/api/schemas/watchlist.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WatchlistType(str, Enum):
+    country = "country"
+    port = "port"
+    chokepoint = "chokepoint"
+    hs = "hs"
+    company = "company"
+
+
+class WatchlistCreate(BaseModel):
+    name: str
+    type: WatchlistType
+
+
+class Watchlist(WatchlistCreate):
+    id: uuid.UUID
+
+
+class WatchlistItem(BaseModel):
+    ref_id: str
+    label: str | None = None
+    meta: dict[str, Any] | None = None
+
+
+class WatchlistItemsUpsert(BaseModel):
+    items: list[WatchlistItem] = Field(default_factory=list)

--- a/app/db/migrations/versions/0003_add_portfolio_watchlist_alert_tables.py
+++ b/app/db/migrations/versions/0003_add_portfolio_watchlist_alert_tables.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolios",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_table(
+        "portfolio_holdings",
+        sa.Column(
+            "portfolio_id",
+            sa.UUID(),
+            sa.ForeignKey("portfolios.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("symbol", sa.String(), primary_key=True),
+        sa.Column("as_of", sa.Date(), primary_key=True),
+        sa.Column("weight", sa.Float(), nullable=True),
+        sa.Column("shares", sa.Float(), nullable=True),
+    )
+    op.create_table(
+        "watchlists",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+    )
+    op.create_table(
+        "watchlist_items",
+        sa.Column(
+            "watchlist_id",
+            sa.UUID(),
+            sa.ForeignKey("watchlists.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("ref_id", sa.String(), primary_key=True),
+        sa.Column("label", sa.String(), nullable=True),
+        sa.Column("meta", sa.JSON(), nullable=True),
+    )
+    op.create_table(
+        "alert_rules",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("rule_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column("cooldown_s", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_table(
+        "alert_deliveries",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "rule_id",
+            sa.UUID(),
+            sa.ForeignKey("alert_rules.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("target", sa.String(), nullable=False),
+        sa.Column("secret", sa.String(), nullable=True),
+        sa.Column(
+            "active", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+    )
+    op.create_table(
+        "alert_events",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "rule_id",
+            sa.UUID(),
+            sa.ForeignKey("alert_rules.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "fired_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("dedupe_key", sa.String(), nullable=False),
+        sa.Column(
+            "delivered", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.Column("attempts", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_error", sa.String(), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_alert_events_rule_dedupe",
+        "alert_events",
+        ["rule_id", "dedupe_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_alert_events_rule_dedupe", "alert_events", type_="unique")
+    op.drop_table("alert_events")
+    op.drop_table("alert_deliveries")
+    op.drop_table("alert_rules")
+    op.drop_table("watchlist_items")
+    op.drop_table("watchlists")
+    op.drop_table("portfolio_holdings")
+    op.drop_table("portfolios")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
 import uuid
+from datetime import date, datetime
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -36,3 +46,132 @@ class ApiKey(Base):
     key_hmac: Mapped[str] = mapped_column(String, nullable=False)
 
     user: Mapped[User] = relationship(back_populates="api_keys")
+
+
+class Portfolio(Base):
+    __tablename__ = "portfolios"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    holdings: Mapped[list["PortfolioHolding"]] = relationship(
+        back_populates="portfolio", cascade="all, delete-orphan"
+    )
+
+
+class PortfolioHolding(Base):
+    __tablename__ = "portfolio_holdings"
+
+    portfolio_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("portfolios.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    symbol: Mapped[str] = mapped_column(String, primary_key=True)
+    as_of: Mapped[date] = mapped_column(Date, primary_key=True)
+    weight: Mapped[float | None] = mapped_column(Float, nullable=True)
+    shares: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    portfolio: Mapped[Portfolio] = relationship(back_populates="holdings")
+
+
+class Watchlist(Base):
+    __tablename__ = "watchlists"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    type: Mapped[str] = mapped_column(String, nullable=False)
+
+    items: Mapped[list["WatchlistItem"]] = relationship(
+        back_populates="watchlist", cascade="all, delete-orphan"
+    )
+
+
+class WatchlistItem(Base):
+    __tablename__ = "watchlist_items"
+
+    watchlist_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("watchlists.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    ref_id: Mapped[str] = mapped_column(String, primary_key=True)
+    label: Mapped[str | None] = mapped_column(String, nullable=True)
+    meta: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    watchlist: Mapped[Watchlist] = relationship(back_populates="items")
+
+
+class AlertRule(Base):
+    __tablename__ = "alert_rules"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    rule_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    cooldown_s: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    deliveries: Mapped[list["AlertDelivery"]] = relationship(
+        back_populates="rule", cascade="all, delete-orphan"
+    )
+
+
+class AlertDelivery(Base):
+    __tablename__ = "alert_deliveries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    rule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("alert_rules.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    target: Mapped[str] = mapped_column(String, nullable=False)
+    secret: Mapped[str | None] = mapped_column(String, nullable=True)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    rule: Mapped[AlertRule] = relationship(back_populates="deliveries")
+
+
+class AlertEvent(Base):
+    __tablename__ = "alert_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    rule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("alert_rules.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    fired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    payload_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    dedupe_key: Mapped[str] = mapped_column(String, nullable=False)
+    delivered: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_error: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/tests/api/test_alerts.py
+++ b/tests/api/test_alerts.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_headers() -> dict[str, str]:
+    resp = client.post(
+        "/auth/login", data={"username": "admin@example.com", "password": "password"}
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@patch("app.api.routers.alerts.db.fetch_all", new_callable=MagicMock)
+def test_list_rules(fetch_all: MagicMock) -> None:
+    fetch_all.return_value = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "R1",
+            "rule_json": {},
+            "enabled": True,
+            "cooldown_s": 0,
+            "created_at": "2024-01-01T00:00:00",
+        }
+    ]
+    resp = client.get("/v1/alerts/rules", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["name"] == "R1"
+    fetch_all.assert_called_once()
+
+
+@patch("app.api.routers.alerts.db.fetch_one", new_callable=MagicMock)
+def test_create_rule(fetch_one: MagicMock) -> None:
+    fetch_one.return_value = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "R1",
+        "rule_json": {},
+        "enabled": True,
+        "cooldown_s": 0,
+        "created_at": "2024-01-01T00:00:00",
+    }
+    resp = client.post(
+        "/v1/alerts/rules",
+        json={"name": "R1", "rule_json": {}, "cooldown_s": 0},
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["id"] == "11111111-1111-1111-1111-111111111111"
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.alerts.db.fetch_one", new_callable=MagicMock)
+def test_enable_rule(fetch_one: MagicMock) -> None:
+    fetch_one.return_value = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "R1",
+        "rule_json": {},
+        "enabled": True,
+        "cooldown_s": 0,
+        "created_at": "2024-01-01T00:00:00",
+    }
+    resp = client.post(
+        "/v1/alerts/rules/11111111-1111-1111-1111-111111111111/enable",
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 200
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.alerts.db.fetch_one", new_callable=MagicMock)
+def test_create_delivery(fetch_one: MagicMock) -> None:
+    fetch_one.return_value = {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "rule_id": "11111111-1111-1111-1111-111111111111",
+        "kind": "email",
+        "target": "user@example.com",
+        "secret": None,
+        "active": True,
+    }
+    resp = client.post(
+        "/v1/alerts/deliveries",
+        json={
+            "rule_id": "11111111-1111-1111-1111-111111111111",
+            "kind": "email",
+            "target": "user@example.com",
+            "secret": None,
+        },
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 201
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.alerts.db.fetch_all", new_callable=MagicMock)
+def test_list_events(fetch_all: MagicMock) -> None:
+    fetch_all.return_value = [
+        {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "rule_id": "11111111-1111-1111-1111-111111111111",
+            "fired_at": "2024-01-01T00:00:00",
+            "payload_json": {},
+            "dedupe_key": "k",
+            "delivered": False,
+            "attempts": 0,
+            "last_error": None,
+        }
+    ]
+    resp = client.get("/v1/alerts/events", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["id"] == "33333333-3333-3333-3333-333333333333"
+    fetch_all.assert_called_once()

--- a/tests/api/test_portfolio.py
+++ b/tests/api/test_portfolio.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_headers() -> dict[str, str]:
+    resp = client.post(
+        "/auth/login", data={"username": "admin@example.com", "password": "password"}
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@patch("app.api.routers.portfolio.db.fetch_all", new_callable=MagicMock)
+def test_list_portfolios(fetch_all: MagicMock) -> None:
+    fetch_all.return_value = [
+        {"id": "p1", "name": "Test", "created_at": "2024-01-01T00:00:00"}
+    ]
+    resp = client.get("/v1/portfolio", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["name"] == "Test"
+    fetch_all.assert_called_once()
+
+
+@patch("app.api.routers.portfolio.db.fetch_one", new_callable=MagicMock)
+def test_create_portfolio(fetch_one: MagicMock) -> None:
+    fetch_one.return_value = {
+        "id": "p1",
+        "name": "P1",
+        "created_at": "2024-01-01T00:00:00",
+    }
+    resp = client.post("/v1/portfolio", json={"name": "P1"}, headers=auth_headers())
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "P1"
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.portfolio.db.fetch_one", new_callable=MagicMock)
+def test_upsert_holdings(fetch_one: MagicMock) -> None:
+    fetch_one.side_effect = [
+        None,
+        {
+            "portfolio_id": "11111111-1111-1111-1111-111111111111",
+            "symbol": "AAPL",
+            "weight": 0.5,
+            "shares": None,
+            "as_of": "2024-01-01",
+        },
+    ]
+    resp = client.put(
+        "/v1/portfolio/11111111-1111-1111-1111-111111111111/holdings",
+        json={
+            "holdings": [
+                {
+                    "symbol": "AAPL",
+                    "weight": 0.5,
+                    "shares": None,
+                    "as_of": "2024-01-01",
+                }
+            ]
+        },
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 200
+    assert fetch_one.call_count == 2

--- a/tests/api/test_watchlist.py
+++ b/tests/api/test_watchlist.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_headers() -> dict[str, str]:
+    resp = client.post(
+        "/auth/login", data={"username": "admin@example.com", "password": "password"}
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@patch("app.api.routers.watchlist.db.fetch_all", new_callable=MagicMock)
+def test_list_watchlists(fetch_all: MagicMock) -> None:
+    fetch_all.return_value = [{"id": "w1", "name": "WL", "type": "country"}]
+    resp = client.get("/v1/watchlist", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["id"] == "w1"
+    fetch_all.assert_called_once()
+
+
+@patch("app.api.routers.watchlist.db.fetch_one", new_callable=MagicMock)
+def test_create_watchlist(fetch_one: MagicMock) -> None:
+    fetch_one.return_value = {
+        "id": "w1",
+        "name": "WL",
+        "type": "country",
+    }
+    resp = client.post(
+        "/v1/watchlist",
+        json={"name": "WL", "type": "country"},
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["id"] == "w1"
+    fetch_one.assert_called_once()
+
+
+@patch("app.api.routers.watchlist.db.fetch_one", new_callable=MagicMock)
+def test_upsert_items(fetch_one: MagicMock) -> None:
+    fetch_one.side_effect = [
+        None,
+        {
+            "watchlist_id": "11111111-1111-1111-1111-111111111111",
+            "ref_id": "US",
+            "label": "United States",
+            "meta": None,
+        },
+    ]
+    resp = client.put(
+        "/v1/watchlist/11111111-1111-1111-1111-111111111111/items",
+        json={"items": [{"ref_id": "US", "label": "United States", "meta": None}]},
+        headers=auth_headers(),
+    )
+    assert resp.status_code == 200
+    assert fetch_one.call_count == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+def test_models_import() -> None:
+    """Ensure SQLAlchemy models module imports without errors."""
+    models: ModuleType = importlib.import_module("app.db.models")
+    assert hasattr(models, "User")
+    assert hasattr(models, "AlertRule")


### PR DESCRIPTION
## Summary
- add pydantic schemas for alert rules, deliveries, and events
- implement alerts router with rule CRUD, delivery config, and event listing
- register alerts router on v1 API and add unit tests

## Testing
- `pre-commit run --files app/api/schemas/alerts.py app/api/routers/alerts.py app/api/routers/v1.py tests/api/test_alerts.py`
- `pytest tests/api/test_alerts.py -q --disable-warnings` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a27b3cdd148323b5e1cbd7a30956e8