### PR TITLE
feat: add basic risk endpoint

### DIFF
--- a/app/api/routers/risk.py
+++ b/app/api/routers/risk.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from fastapi import APIRouter, Query
+from fastapi.concurrency import run_in_threadpool
+
+from app.core import cache, db
+
+router = APIRouter(tags=["risk"])
+
+_DEFAULT_METRICS = ["macro", "market", "commodity", "geo", "logistics"]
+
+
+@router.get("/risk")
+async def get_risk_score(
+    country: str = Query(..., min_length=3, max_length=3),
+) -> Dict[str, Any]:
+    """Return simple aggregated risk scores for a given country.
+
+    The endpoint queries a set of pre-computed risk metrics and returns their
+    weighted average. If a metric is missing it is treated as ``0``.
+    """
+    key = f"risk:{country.upper()}"
+    cached = await cache.cache_get(key)
+    if cached:
+        if isinstance(cached, (bytes, str)):
+            return json.loads(cached)
+        return cached
+
+    sql = (
+        "SELECT metric, value FROM risk_metrics "
+        "WHERE entity_id = %(country)s AND metric = ANY(%(metrics)s)"
+    )
+    params = {"country": country.upper(), "metrics": _DEFAULT_METRICS}
+    rows = await run_in_threadpool(db.fetch_all, sql, params)
+
+    scores = {m: 0.0 for m in _DEFAULT_METRICS}
+    for row in rows:
+        metric = row.get("metric")
+        value = row.get("value", 0.0)
+        if metric in scores:
+            scores[metric] = value
+
+    risk = sum(scores.values()) / len(scores) if scores else 0.0
+    resp = {"country": country.upper(), "scores": scores, "risk": risk}
+    await cache.cache_set(key, json.dumps(resp))
+    return resp

--- a/app/api/routers/v1.py
+++ b/app/api/routers/v1.py
@@ -15,6 +15,7 @@ from . import (
     portfolio,
     ports,
     rates,
+    risk,
     trade,
     watchlist,
 )
@@ -34,3 +35,4 @@ router.include_router(assets.router)
 router.include_router(portfolio.router)
 router.include_router(watchlist.router)
 router.include_router(alerts.router)
+router.include_router(risk.router)

--- a/tests/api/test_risk.py
+++ b/tests/api/test_risk.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@patch("app.api.routers.risk.cache.cache_get", new_callable=AsyncMock)
+@patch("app.api.routers.risk.cache.cache_set", new_callable=AsyncMock)
+@patch("app.api.routers.risk.db.fetch_all", new_callable=MagicMock)
+def test_get_risk_score(
+    fetch_all: MagicMock,
+    cache_set: AsyncMock,
+    cache_get: AsyncMock,
+) -> None:
+    cache_get.return_value = None
+    fetch_all.return_value = [
+        {"metric": "macro", "value": 0.2},
+        {"metric": "market", "value": 0.3},
+        {"metric": "commodity", "value": 0.4},
+        {"metric": "geo", "value": 0.1},
+        {"metric": "logistics", "value": 0.2},
+    ]
+    resp = client.get("/v1/risk", params={"country": "USA"})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "country": "USA",
+        "scores": {
+            "macro": 0.2,
+            "market": 0.3,
+            "commodity": 0.4,
+            "geo": 0.1,
+            "logistics": 0.2,
+        },
+        "risk": 0.24,
+    }
+    fetch_all.assert_called_once()


### PR DESCRIPTION
## Summary
- expose simple aggregated risk scores via new /v1/risk endpoint
- register risk router in API v1
- test risk endpoint aggregation logic

## Testing
- `pre-commit run --files app/api/routers/risk.py app/api/routers/v1.py tests/api/test_risk.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd16c43c83239419905bb855495a